### PR TITLE
fix: add mv3 compatibility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,8 +20,11 @@ export const hasAPI = (nsps: string): boolean => browser[nsps]
 export const getBackgroundPageType = () => {
   const manifest: Manifest.WebExtensionManifest = browser.runtime.getManifest()
 
-  if (manifest.browser_action?.default_popup) {
-    const url = new URL(browser.runtime.getURL(manifest.browser_action.default_popup))
+  if (typeof window === 'undefined') return 'background'
+
+  const popupPage = manifest.browser_action?.default_popup || manifest.action?.default_popup
+  if (popupPage) {
+    const url = new URL(browser.runtime.getURL(popupPage))
     if (url.pathname === window.location.pathname) return 'popup'
   }
 


### PR DESCRIPTION
in [mv3](https://developer.chrome.com/docs/extensions/mv3/intro/), `background` has no `window` object any more because that it's running as Service Worker, and popup config was moved to `action` field in manifest.