### PR TITLE
feat: allow to specify frameId

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Example: `devtools` or `content-script` or `background` or `content-script@133` 
 
 `content-script`, `window` and `devtools` destinations can be suffixed with `@<tabId>` to target specific tab. Example: `devtools@351`, points to devtools panel inspecting tab with id 351.
 
+For `content-script`, a specific `frameId` can be specified by appending the `frameId` to the suffix `@<tabId>.<frameId>`.
+
 Read `Behavior` section to see how destinations (or endpoints) are treated.
 
 > Note: For security reasons, if you want to receive or send messages to or from `window` context, one of your extension's content script must call `allowWindowMessaging(<namespace: string>)` to unlock message routing. Also call `setNamespace(<namespace: string>)` in those `window` contexts. Use same namespace string in those two calls, so `webext-bridge` knows which message belongs to which extension (in case multiple extensions are using `webext-bridge` in one page)

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type RuntimeContext = 'devtools' | 'background' | 'popup' | 'options' | '
 export type Endpoint = {
   context: RuntimeContext
   tabId: number
+  frameId?: number
 }
 
 export interface IBridgeMessage<T extends JsonValue> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,15 @@
 import browser, { Manifest } from 'webextension-polyfill'
 import { Endpoint, RuntimeContext } from './types'
 
-const ENDPOINT_RE = /^((?:background$)|devtools|popup|options|content-script|window)(?:@(\d+))?$/
+const ENDPOINT_RE = /^((?:background$)|devtools|popup|options|content-script|window)(?:@(\d+)(?:\.(\d+))?)?$/
 
 export const parseEndpoint = (endpoint: string): Endpoint => {
-  const [, context, tabId] = endpoint.match(ENDPOINT_RE) || []
+  const [, context, tabId, frameId] = endpoint.match(ENDPOINT_RE) || []
 
   return {
     context: context as RuntimeContext,
     tabId: +tabId,
+    frameId: frameId ? +frameId : undefined,
   }
 }
 


### PR DESCRIPTION
## Problem

If a content_script is injected in multiple frames, sometimes we wish to send a message to a specific frame, instead of the content script at the top. This PR  includes:

- A way to specify a the target `frameId` with the `@<tabId>.<frameId>` suffix
- Allow frames to connect via `browser.runtime.connect()`
- Send a message to the specified frame only

## Nice things for the future

- [ ] "Broadcast" a message to all ports inside a document (all injected content scripts in all frames)
- [ ] Adding a flag to connect or not from all frames. for example, something in `initIntercoms({allFrames: true})`

## Linked issue

https://github.com/antfu/webext-bridge/issues/2


## Screenshots


### Sending a message to the top frame

![image](https://user-images.githubusercontent.com/8704336/147523662-a7f2246c-6949-4bf4-bc26-c060eea68711.png)


### Sending a message to an iframe
![image](https://user-images.githubusercontent.com/8704336/147523734-c0afeb79-c0fa-439e-85b5-d0e7861c9f07.png)
