### PR TITLE
fix: add cjs build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm,cjs --dts",
     "watch": "npm run build -- --watch",
     "release": "bumpp --commit --push --tag && npm run build && npm publish"
   },


### PR DESCRIPTION
cjs target is missing:
https://github.com/antfu/webext-bridge/blob/818423368a7d68923e52457757fc2c3ee9891a47/package.json#L24-L28

close #10 

https://github.com/antfu/vitesse-webext/issues/65