### PR TITLE
fix: support interfaces and toJSON-able values in ProtocolWithReturn

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { JsonValue } from 'type-fest'
+import { Jsonify, JsonValue } from 'type-fest'
 
 export type RuntimeContext = 'devtools' | 'background' | 'popup' | 'options' | 'content-script' | 'window'
 
@@ -50,9 +50,9 @@ export type Destination = Endpoint | RuntimeContext | string
 
 declare const ProtocolWithReturnSymbol: unique symbol
 
-export interface ProtocolWithReturn<Data extends JsonValue, Return extends JsonValue> {
-  data: Data
-  return: Return
+export interface ProtocolWithReturn<Data, Return> {
+  data: Jsonify<Data>
+  return: Jsonify<Return>
   /**
    * Type differentiator only.
    */


### PR DESCRIPTION
Fixes #16 

Uses type-fest's [jsonify](https://github.com/sindresorhus/type-fest/blob/main/source/jsonify.d.ts) to transform types passed into ProtocolWithReturn into JsonValue types.

This fixes usages with interfaces and also adds support for values that implement `.toJSON` like `Date`.

Currently, non-JsonValue types like interfaces get transformed into `void`. With this change, values that jsonify can't transform end up as `never`.