### PR TITLE
Fixes bug where messages from frameId 0 weren't having sender.frameId set

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -202,7 +202,7 @@ export function routeMessage(message: IInternalMessage): void | Promise<void> {
         : (`${(destName === 'window' ? 'content-script' : destName)}@${(destTabId || srcTabId)}`)
 
       // Here it is checked if a specific frame needs to receive the message
-      if (destFrameId)
+      if (destFrameId !== undefined)
         resolvedDestination = `${resolvedDestination}.${destFrameId}`
 
       const destPort = portMap.get(resolvedDestination)


### PR DESCRIPTION
A value of `0` for `frameId` is valid. However, the existing code was skipping this due to a truthiness check. This has been replaced with an explicit `frameId === undefined` check instead.
