### PR TITLE
feat: add types field to package.json for TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "webext-bridge",
   "version": "6.0.1",
+  "types": "./dist/index.d.ts",
   "description": "Messaging in Web Extensions made easy. Out of the box.",
   "keywords": [
     "chrome",


### PR DESCRIPTION
The package is already written in TypeScript and includes .d.ts files in the dist folder, but the `types` field is missing from package.json.

This simple addition enables TypeScript users to get proper type hints when importing this package without needing to install a separate @types/webext-bridge package.

Before:
```json
{
  name: webext-bridge,
  version: 6.0.1
}
```

After:
```json
{
  name: webext-bridge,
  version: 6.0.1,
  types: ./dist/index.d.ts
}
```

This follows the same pattern used by other popular extension packages like webext-messenger, webext-detect, and webext-permissions.